### PR TITLE
Add assertion helpers and create_guild(id=...)

### DIFF
--- a/changes/+assert-helpers.feature.md
+++ b/changes/+assert-helpers.feature.md
@@ -1,0 +1,1 @@
+Added assertion helpers — `assert_sent`, `assert_responded`, `assert_message`, `assert_error` and `assert_no_errors` — whose failure messages print what the bot actually did (the channel's recent history, the interaction result, the captured errors).

--- a/changes/+create-guild-id.feature.md
+++ b/changes/+create-guild-id.feature.md
@@ -1,0 +1,1 @@
+`Env.create_guild` now accepts an optional `id=` so a guild can be pinned to a known id — e.g. to match a bot that syncs its commands to a hardcoded guild id, keeping `strict_sync` on.

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,6 +48,21 @@ Returned by the interaction verbs (`slash`, `context_menu`, `click`, `select`,
 
 ::: simcord.ResponseMessage
 
+## Assertions
+
+Runner-agnostic helpers whose failure messages print what the bot actually did. See
+[Errors & diagnostics → Assertions](guides/diagnostics.md#assertions).
+
+::: simcord.assert_sent
+
+::: simcord.assert_responded
+
+::: simcord.assert_message
+
+::: simcord.assert_error
+
+::: simcord.assert_no_errors
+
 ## Errors
 
 ::: simcord.BackendError

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -50,6 +50,48 @@ async with simcord.run(bot, check_errors=False) as env:
 `ExceptionGroup` of everything captured (even a single error) and does nothing if there were
 none.
 
+## Assertions
+
+You can assert with plain `assert` on the [result and query objects](../api.md), but SimCord
+also ships a few helpers whose **failure messages show what the bot actually did** — so a red
+test explains itself. They're plain functions (no pytest required) importable from the top
+level:
+
+```python
+from simcord import assert_sent, assert_responded, assert_error
+
+await alice.send(channel, "!ping")
+assert_sent(channel, content="Pong!")           # the channel's last visible message
+
+result = await alice.slash(channel, "hello")
+assert_responded(result, contains="hi", ephemeral=True)   # the interaction's response
+```
+
+Each field (`content`, `contains`, `embed_title`, `ephemeral`) is checked only when you pass
+it. When an assertion fails, the message includes the real output — e.g. `assert_sent` prints
+the channel's recent history, and `assert_responded` prints whether the bot deferred or opened
+a modal instead:
+
+```
+AssertionError: last message did not match:
+  content: expected 'Pong!', got 'Pnog!'
+recent messages:
+  - 'Pnog!'
+```
+
+For errors, `assert_error` replaces the clunky `any(isinstance(e, ...) for e in env.errors)`
+idiom and unwraps discord.py's `CommandInvokeError.original` for you:
+
+```python
+env.inject_error("POST", "/channels/*/messages", status=403, code=50013)
+await alice.send(channel, "!post")
+assert_error(env, discord.Forbidden, code=50013)   # matches the wrapped original
+assert_no_errors(env)                               # the symmetric "ran cleanly" check
+```
+
+`assert_error` reads `env.errors`, which counts as inspecting them (see below), so it also
+satisfies the teardown guard.
+
 ## The transcript
 
 `env.transcript()` returns a human-readable, ordered record of everything that crossed

--- a/docs/guides/fixtures.md
+++ b/docs/guides/fixtures.md
@@ -103,6 +103,16 @@ async with simcord.run(bot, strict_sync=False) as env:
     ...
 ```
 
+!!! tip "Bot syncs to a hardcoded guild id?"
+    Some bots pin `tree.sync(guild=discord.Object(id=...))` to a specific guild id. Pass that
+    same id to `create_guild` so the synced commands land in a guild that exists, and
+    `strict_sync` can stay on:
+
+    ```python
+    MY_GUILD = 123456789012345678  # the id the bot syncs to
+    guild = env.create_guild(id=MY_GUILD)
+    ```
+
 ### Overriding options per test
 
 Mark a test with `@pytest.mark.simcord(...)` and its keyword arguments are forwarded to

--- a/src/simcord/__init__.py
+++ b/src/simcord/__init__.py
@@ -25,6 +25,13 @@ from . import _dpy_internals
 _dpy_internals.verify()
 
 from .actors import MemberActor  # noqa: E402
+from .asserts import (  # noqa: E402
+    assert_error,
+    assert_message,
+    assert_no_errors,
+    assert_responded,
+    assert_sent,
+)
 from .backend import Backend  # noqa: E402, F401  — importable for advanced use, but NOT public API:
 
 # Backend's methods and payload shapes are internal and may change in any release.
@@ -51,5 +58,10 @@ __all__ = (
     "RouteNotImplemented",
     "SetupError",
     "UserHandle",
+    "assert_error",
+    "assert_message",
+    "assert_no_errors",
+    "assert_responded",
+    "assert_sent",
     "run",
 )

--- a/src/simcord/asserts.py
+++ b/src/simcord/asserts.py
@@ -1,0 +1,180 @@
+"""Assertion helpers with failure messages that show what the bot actually did.
+
+These are plain functions that raise ``AssertionError`` — runner-agnostic, so
+they work under pytest (which renders the message) or plain unittest. Each one
+prints the bot's real output on failure, so a red test explains itself without
+a debugger.
+
+    import simcord
+    from simcord import assert_responded, assert_sent, assert_error
+
+    async with simcord.run(bot) as env:
+        ...
+        assert_sent(channel, content="Pong!")
+        result = await alice.slash(channel, "hello")
+        assert_responded(result, contains="hi", ephemeral=True)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import discord
+
+from .results import InteractionResult, ResponseMessage
+
+if TYPE_CHECKING:
+    from .actors import MemberActor
+    from .builders import ChannelHandle, UserHandle
+    from .env import Env
+
+MessageLike = ResponseMessage | discord.Message
+
+
+def _ephemeral(message: MessageLike) -> bool:
+    if isinstance(message, ResponseMessage):
+        return message.ephemeral
+    return message.flags.ephemeral
+
+
+def _embed_titles(message: MessageLike) -> list[str | None]:
+    return [embed.title for embed in message.embeds]
+
+
+def _check_fields(
+    message: MessageLike,
+    *,
+    content: str | None,
+    contains: str | None,
+    embed_title: str | None,
+    ephemeral: bool | None,
+) -> list[str]:
+    """Return a list of human-readable mismatches (empty means it matched)."""
+    problems = []
+    if content is not None and message.content != content:
+        problems.append(f"  content: expected {content!r}, got {message.content!r}")
+    if contains is not None and contains not in message.content:
+        problems.append(f"  content does not contain {contains!r} (got {message.content!r})")
+    if embed_title is not None:
+        titles = _embed_titles(message)
+        if embed_title not in titles:
+            problems.append(f"  no embed titled {embed_title!r} (embed titles: {titles!r})")
+    if ephemeral is not None and _ephemeral(message) != ephemeral:
+        problems.append(f"  ephemeral: expected {ephemeral}, got {_ephemeral(message)}")
+    return problems
+
+
+def assert_message(
+    message: MessageLike,
+    *,
+    content: str | None = None,
+    contains: str | None = None,
+    embed_title: str | None = None,
+    ephemeral: bool | None = None,
+) -> None:
+    """Assert a single message matches the given fields. Each field is checked
+    only when provided. Accepts a ``ResponseMessage`` or a real ``discord.Message``."""
+    problems = _check_fields(
+        message, content=content, contains=contains, embed_title=embed_title, ephemeral=ephemeral
+    )
+    if problems:
+        raise AssertionError("message did not match:\n" + "\n".join(problems) + f"\nactual: {message!r}")
+
+
+def assert_sent(
+    channel: ChannelHandle,
+    *,
+    content: str | None = None,
+    contains: str | None = None,
+    embed_title: str | None = None,
+    viewer: MemberActor | UserHandle | None = None,
+) -> None:
+    """Assert the channel's most recent (visible) message matches.
+
+    ``viewer=`` filters to what that user can see, hiding ephemeral messages
+    addressed to others — the same rule as :meth:`ChannelHandle.history`.
+    """
+    history = channel.history(viewer=viewer)
+    if not history:
+        raise AssertionError(f"expected a message in {channel!r}, but none was sent")
+    last = history[-1]
+    problems = _check_fields(
+        last, content=content, contains=contains, embed_title=embed_title, ephemeral=None
+    )
+    if problems:
+        recent = "\n".join(f"  - {m.content!r}" for m in history[-5:])
+        raise AssertionError(
+            "last message did not match:\n" + "\n".join(problems) + f"\nrecent messages:\n{recent}"
+        )
+
+
+def assert_responded(
+    result: InteractionResult,
+    *,
+    content: str | None = None,
+    contains: str | None = None,
+    embed_title: str | None = None,
+    ephemeral: bool | None = None,
+) -> None:
+    """Assert the interaction produced a response message matching the given fields."""
+    response = result.response
+    if response is None:
+        raise AssertionError(f"interaction produced no response message\nactual: {result!r}")
+    problems = _check_fields(
+        response, content=content, contains=contains, embed_title=embed_title, ephemeral=ephemeral
+    )
+    if problems:
+        raise AssertionError(
+            "interaction response did not match:\n" + "\n".join(problems) + f"\nactual: {result!r}"
+        )
+
+
+def assert_error(
+    env: Env,
+    exc_type: type[BaseException] = BaseException,
+    *,
+    code: int | None = None,
+    contains: str | None = None,
+) -> BaseException:
+    """Assert the bot captured an error matching ``exc_type``/``code``/``contains``.
+
+    discord.py wraps callback failures (e.g. ``CommandInvokeError.original``), so
+    the type and code are matched against the error *and* its ``.original``.
+    Returns the matched error. Reading ``env.errors`` marks errors inspected, so
+    this also satisfies the teardown ``check_errors`` guard.
+    """
+    captured = env.errors
+
+    def matches(error: BaseException) -> bool:
+        candidates = [error]
+        original = getattr(error, "original", None)
+        if original is not None:
+            candidates.append(original)
+        if not any(isinstance(c, exc_type) for c in candidates):
+            return False
+        if code is not None and not any(getattr(c, "code", None) == code for c in candidates):
+            return False
+        if contains is not None and not any(contains in str(c) for c in candidates):
+            return False
+        return True
+
+    for error in captured:
+        if matches(error):
+            return error
+
+    wanted = [exc_type.__name__]
+    if code is not None:
+        wanted.append(f"code={code}")
+    if contains is not None:
+        wanted.append(f"containing {contains!r}")
+    if not captured:
+        raise AssertionError(f"expected an error ({', '.join(wanted)}), but the bot captured none")
+    listed = "\n".join(f"  - {e!r}" for e in captured)
+    raise AssertionError(f"no captured error matched ({', '.join(wanted)}); captured:\n{listed}")
+
+
+def assert_no_errors(env: Env) -> None:
+    """Assert the bot ran cleanly: raises an ``ExceptionGroup`` of anything it
+    captured, or does nothing. A clearer-named pairing for :func:`assert_error`
+    over :meth:`Env.raise_errors`."""
+    env.raise_errors()

--- a/src/simcord/asserts.py
+++ b/src/simcord/asserts.py
@@ -116,7 +116,10 @@ def assert_responded(
     embed_title: str | None = None,
     ephemeral: bool | None = None,
 ) -> None:
-    """Assert the interaction produced a response message matching the given fields."""
+    """Assert the interaction produced a response message matching the given fields.
+
+    On failure the message includes the interaction's repr, which shows whether it
+    acknowledged, deferred, or opened a modal instead of sending a response."""
     response = result.response
     if response is None:
         raise AssertionError(f"interaction produced no response message\nactual: {result!r}")
@@ -146,6 +149,10 @@ def assert_error(
     captured = env.errors
 
     def matches(error: BaseException) -> bool:
+        # Match against the error and its unwrapped .original. Each criterion is
+        # checked across both candidates independently — in the common case the
+        # wrapped original satisfies all of them together (discord.py puts the
+        # type, code and message on the original, not the CommandInvokeError).
         candidates = [error]
         original = getattr(error, "original", None)
         if original is not None:

--- a/src/simcord/backend/state.py
+++ b/src/simcord/backend/state.py
@@ -133,8 +133,8 @@ class Backend:
 
     # ---------------------------------------------------------------- guilds
 
-    def create_guild(self, name: str, *, owner_id: int | None = None) -> Guild:
-        guild_id = self.snowflake()
+    def create_guild(self, name: str, *, id: int | None = None, owner_id: int | None = None) -> Guild:
+        guild_id = id if id is not None else self.snowflake()
         if owner_id is None:
             # A synthetic owner: the bot must never own guilds by default,
             # since owners bypass every permission check.

--- a/src/simcord/env.py
+++ b/src/simcord/env.py
@@ -284,8 +284,10 @@ class Env:
     def create_user(self, name: str) -> UserHandle:
         return UserHandle(self, self.backend.make_user(name))
 
-    def create_guild(self, name: str = "Test Guild") -> GuildHandle:
-        handle = GuildHandle(self, self.backend.create_guild(name))
+    def create_guild(self, name: str = "Test Guild", *, id: int | None = None) -> GuildHandle:
+        """Create a guild. Pass ``id`` to pin a known id — e.g. to match a bot that
+        syncs its commands to a hardcoded guild id, so ``strict_sync`` can stay on."""
+        handle = GuildHandle(self, self.backend.create_guild(name, id=id))
         self._guilds.append(handle)
         return handle
 

--- a/tests/integration/test_asserts.py
+++ b/tests/integration/test_asserts.py
@@ -1,0 +1,119 @@
+import discord
+import pytest
+
+import simcord
+from fixtures.sample_bot import create_bot
+from simcord import (
+    assert_error,
+    assert_message,
+    assert_no_errors,
+    assert_responded,
+    assert_sent,
+)
+
+# ----------------------------------------------------------------- assert_sent
+
+
+async def test_assert_sent_matches(channel, alice):
+    await alice.send(channel, "!ping")
+    assert_sent(channel, content="Pong!")
+    assert_sent(channel, contains="Pong")
+
+
+async def test_assert_sent_mismatch_shows_recent_history(channel, alice):
+    await alice.send(channel, "!ping")
+    with pytest.raises(AssertionError) as exc:
+        assert_sent(channel, content="nope")
+    message = str(exc.value)
+    assert "'nope'" in message
+    assert "'Pong!'" in message  # the actual content is shown
+
+
+async def test_assert_sent_when_nothing_sent(env):
+    empty = env.guild.create_text_channel("empty")
+    with pytest.raises(AssertionError, match="none was sent"):
+        assert_sent(empty, content="anything")
+
+
+# ------------------------------------------------------------ assert_responded
+
+
+async def test_assert_responded_matches(channel, alice):
+    result = await alice.slash(channel, "config set", key="lang", value="en")
+    assert_responded(result, content="lang=en")
+
+
+async def test_assert_responded_ephemeral(env, channel, alice):
+    bob = env.guild.add_member(env.create_user("bob"))
+    result = await alice.context_menu(channel, "Report Member", bob)
+    assert_responded(result, content="Reported bob", ephemeral=True)
+
+
+async def test_assert_responded_mismatch_shows_result(channel, alice):
+    result = await alice.slash(channel, "config set", key="lang", value="en")
+    with pytest.raises(AssertionError) as exc:
+        assert_responded(result, content="wrong")
+    assert "lang=en" in str(exc.value)
+
+
+# -------------------------------------------------------------- assert_message
+
+
+async def test_assert_message_on_real_discord_message(channel, alice):
+    await alice.send(channel, "!ping")
+    assert_message(channel.last_message, content="Pong!")
+
+
+async def test_assert_message_on_response(channel, alice):
+    result = await alice.slash(channel, "config set", key="lang", value="en")
+    assert_message(result.response, content="lang=en")
+
+
+# ---------------------------------------------------------------- assert_error
+
+
+async def test_assert_error_matches_wrapped_original(env, channel, alice):
+    env.inject_error("POST", "/channels/*/messages", status=403, code=50013, times=None)
+    await alice.send(channel, "!ping")
+
+    error = assert_error(env, discord.Forbidden, code=50013)
+    assert error is not None
+
+
+async def test_assert_error_none_captured(env):
+    with pytest.raises(AssertionError, match="captured none"):
+        assert_error(env, discord.Forbidden)
+
+
+async def test_assert_error_no_match_lists_captured(env, channel, alice):
+    env.inject_error("POST", "/channels/*/messages", status=403, code=50013, times=None)
+    await alice.send(channel, "!ping")
+
+    with pytest.raises(AssertionError, match="no captured error matched"):
+        assert_error(env, KeyError)
+
+
+# ------------------------------------------------------------ assert_no_errors
+
+
+async def test_assert_no_errors_on_clean_run(env, channel, alice):
+    await alice.send(channel, "!ping")
+    assert_no_errors(env)
+
+
+async def test_assert_no_errors_raises_when_bot_failed(env, channel, alice):
+    env.inject_error("POST", "/channels/*/messages", status=403, code=50013, times=None)
+    await alice.send(channel, "!ping")
+
+    with pytest.raises(BaseExceptionGroup):
+        assert_no_errors(env)
+
+
+# --------------------------------------------------------- create_guild(id=...)
+
+
+async def test_create_guild_with_pinned_id():
+    bot = create_bot()
+    async with simcord.run(bot) as env:
+        guild = env.create_guild(id=987654321012345678)
+        assert guild.id == 987654321012345678


### PR DESCRIPTION
## Summary

Adds the assertion-helper layer (deliberately deferred from the polish round until real usage existed — the dogfood suite is now that usage) and resolves the one open DX papercut, #7.

### Assertion helpers (`simcord.asserts`, re-exported from the package)

Runner-agnostic functions whose failure messages print **what the bot actually did**:

- `assert_sent(channel, …)` — the channel's last visible message; prints recent history on failure
- `assert_responded(result, …)` — the interaction's response; shows defer/modal state on failure
- `assert_message(msg, …)` — shared primitive over `ResponseMessage` / `discord.Message`
- `assert_error(env, exc_type, code=…, contains=…)` — replaces the clunky `any(isinstance(e, …) for e in env.errors)` idiom and unwraps discord.py's `CommandInvokeError.original`; reading `env.errors` marks them inspected
- `assert_no_errors(env)` — symmetric "ran cleanly" check

Each field is checked only when provided; all raise plain `AssertionError` so pytest renders them and plain unittest works too.

### Resolves #7 — guild-pinned sync

`Env.create_guild(id=...)` lets a test pin a guild to the id a bot syncs to, so `strict_sync` can stay on instead of falling back to a global sync.

## Tests & docs

- `tests/integration/test_asserts.py` — each helper's match and failure paths + `create_guild(id=...)`
- Assertions section in the diagnostics guide, helpers in the API reference, guild-pinned-sync tip in the fixtures guide, changelog fragments

## Verification

- `uv run --extra dev pytest tests examples` — 111 passed
- `ruff check` / `ruff format --check` / `pyright src` — clean
- `mkdocs build --strict` — builds
- Gitignored dogfood suite rewritten onto the new helpers + `create_guild(id=MY_GUILD)` — 11 passed

Closes #7.
